### PR TITLE
Fixing shared_ptr that is ambigious under c++11 compilers

### DIFF
--- a/DSLogic-gui/pv/view/analogsignal.cpp
+++ b/DSLogic-gui/pv/view/analogsignal.cpp
@@ -65,7 +65,7 @@ AnalogSignal::~AnalogSignal()
 {
 }
 
-shared_ptr<pv::data::SignalData> AnalogSignal::data() const
+boost::shared_ptr<pv::data::SignalData> AnalogSignal::data() const
 {
     return _data;
 }
@@ -86,7 +86,7 @@ void AnalogSignal::paint_mid(QPainter &p, int left, int right)
     assert(scale > 0);
     const double offset = _view->offset();
 
-	const deque< shared_ptr<pv::data::AnalogSnapshot> > &snapshots =
+	const deque< boost::shared_ptr<pv::data::AnalogSnapshot> > &snapshots =
 		_data->get_snapshots();
 	if (snapshots.empty())
 		return;

--- a/DSLogic-gui/pv/view/devmode.cpp
+++ b/DSLogic-gui/pv/view/devmode.cpp
@@ -68,7 +68,7 @@ void DevMode::set_device()
          l; l = l->next) {
         sr_dev_mode *mode = (sr_dev_mode *)l->data;
 
-        shared_ptr<QPushButton> mode_button = shared_ptr<QPushButton>(new QPushButton(NULL));
+        boost::shared_ptr<QPushButton> mode_button = boost::shared_ptr<QPushButton>(new QPushButton(NULL));
         mode_button->setFlat(true);
         mode_button->setText(mode->name);
 
@@ -97,7 +97,7 @@ void DevMode::paintEvent(QPaintEvent*)
 
     painter.setRenderHint(QPainter::Antialiasing);
     painter.setPen(Qt::NoPen);
-    for(std::map<shared_ptr<QPushButton>, sr_dev_mode *>::const_iterator i = _mode_button_list.begin();
+    for(std::map<boost::shared_ptr<QPushButton>, sr_dev_mode *>::const_iterator i = _mode_button_list.begin();
         i != _mode_button_list.end(); i++) {
         const boost::shared_ptr<device::DevInst> dev_inst = _view.session().get_device();
         assert(dev_inst);
@@ -118,7 +118,7 @@ void DevMode::on_mode_change()
     assert(dev_inst);
     QPushButton *button = qobject_cast<QPushButton *>(sender());
 
-    for(std::map<shared_ptr<QPushButton>, sr_dev_mode *>::const_iterator i = _mode_button_list.begin();
+    for(std::map<boost::shared_ptr<QPushButton>, sr_dev_mode *>::const_iterator i = _mode_button_list.begin();
         i != _mode_button_list.end(); i++) {
         if ((*i).first.get() == button) {
             if (dev_inst->dev_inst()->mode != (*i).second->mode) {

--- a/DSLogic-gui/pv/view/dsosignal.cpp
+++ b/DSLogic-gui/pv/view/dsosignal.cpp
@@ -103,7 +103,7 @@ const int DsoSignal::DownMargin = 30;
 const int DsoSignal::RightMargin = 30;
 
 DsoSignal::DsoSignal(boost::shared_ptr<pv::device::DevInst> dev_inst,
-                     shared_ptr<data::Dso> data,
+                     boost::shared_ptr<data::Dso> data,
                      const sr_channel * const probe):
     Signal(dev_inst, probe, DS_DSO),
     _data(data),
@@ -163,7 +163,7 @@ DsoSignal::~DsoSignal()
 {
 }
 
-shared_ptr<pv::data::SignalData> DsoSignal::data() const
+boost::shared_ptr<pv::data::SignalData> DsoSignal::data() const
 {
     return _data;
 }
@@ -424,7 +424,7 @@ void DsoSignal::paint_mid(QPainter &p, int left, int right)
             return;
 
         _scale = height * 1.0f / 256;
-        const shared_ptr<pv::data::DsoSnapshot> &snapshot =
+        const boost::shared_ptr<pv::data::DsoSnapshot> &snapshot =
             snapshots.front();
 
         const uint16_t number_channels = snapshot->get_channel_num();

--- a/DSLogic-gui/pv/view/groupsignal.cpp
+++ b/DSLogic-gui/pv/view/groupsignal.cpp
@@ -63,7 +63,7 @@ bool GroupSignal::enabled() const
     return true;
 }
 
-shared_ptr<pv::data::SignalData> GroupSignal::data() const
+boost::shared_ptr<pv::data::SignalData> GroupSignal::data() const
 {
     return _data;
 }

--- a/DSLogic-gui/pv/view/header.cpp
+++ b/DSLogic-gui/pv/view/header.cpp
@@ -206,8 +206,8 @@ void Header::mousePressEvent(QMouseEvent *event)
             else
                 mTrace->set_trig(Trace::EDGETRIG);
         } else if (action == Trace::VDIAL && mTrace) {
-            shared_ptr<view::DsoSignal> dsoSig;
-            BOOST_FOREACH(const shared_ptr<Trace> t, traces) {
+            boost::shared_ptr<view::DsoSignal> dsoSig;
+            BOOST_FOREACH(const boost::shared_ptr<Trace> t, traces) {
                 if (dsoSig = dynamic_pointer_cast<view::DsoSignal>(t)) {
                     dsoSig->set_hDialActive(false);
                     if (t != mTrace) {
@@ -218,17 +218,17 @@ void Header::mousePressEvent(QMouseEvent *event)
              if (dsoSig = dynamic_pointer_cast<view::DsoSignal>(mTrace))
                 dsoSig->set_vDialActive(!dsoSig->get_vDialActive());
         } else if (action == Trace::HDIAL && mTrace) {
-            shared_ptr<view::DsoSignal> dsoSig;
+            boost::shared_ptr<view::DsoSignal> dsoSig;
             if (dsoSig = dynamic_pointer_cast<view::DsoSignal>(mTrace)) {
                 if (dsoSig->get_hDialActive()) {
-                    BOOST_FOREACH(const shared_ptr<Trace> t, traces) {
+                    BOOST_FOREACH(const boost::shared_ptr<Trace> t, traces) {
                         if(dsoSig = dynamic_pointer_cast<view::DsoSignal>(t)) {
                             dsoSig->set_vDialActive(false);
                             dsoSig->set_hDialActive(false);
                         }
                     }
                 } else {
-                    BOOST_FOREACH(const shared_ptr<Trace> t, traces) {
+                    BOOST_FOREACH(const boost::shared_ptr<Trace> t, traces) {
                         if(dsoSig = dynamic_pointer_cast<view::DsoSignal>(t)) {
                             dsoSig->set_vDialActive(false);
                             dsoSig->set_hDialActive(true);
@@ -237,12 +237,12 @@ void Header::mousePressEvent(QMouseEvent *event)
                 }
             }
         } else if (action == Trace::CHEN && mTrace) {
-            shared_ptr<view::DsoSignal> dsoSig;
+            boost::shared_ptr<view::DsoSignal> dsoSig;
             if (dsoSig = dynamic_pointer_cast<view::DsoSignal>(mTrace)) {
                 dsoSig->set_enable(!dsoSig->enabled());
             }
         } else if (action == Trace::ACDC && mTrace) {
-            shared_ptr<view::DsoSignal> dsoSig;
+            boost::shared_ptr<view::DsoSignal> dsoSig;
             if (dsoSig = dynamic_pointer_cast<view::DsoSignal>(mTrace))
                 dsoSig->set_acCoupling(!dsoSig->get_acCoupling());
         }
@@ -250,7 +250,7 @@ void Header::mousePressEvent(QMouseEvent *event)
         if (~QApplication::keyboardModifiers() & Qt::ControlModifier) {
             // Unselect all other Traces because the Ctrl is not
             // pressed
-            BOOST_FOREACH(const shared_ptr<Trace> t, traces)
+            BOOST_FOREACH(const boost::shared_ptr<Trace> t, traces)
                 if (t != mTrace)
                     t->select(false);
         }
@@ -293,12 +293,12 @@ void Header::wheelEvent(QWheelEvent *event)
     assert(event);
 
     if (event->orientation() == Qt::Vertical) {
-        const vector< shared_ptr<Trace> > traces(
+        const vector< boost::shared_ptr<Trace> > traces(
             _view.get_traces());
         // Vertical scrolling
         double shift = event->delta() / 20.0;
-        BOOST_FOREACH(const shared_ptr<Trace> t, traces) {
-            shared_ptr<view::DsoSignal> dsoSig;
+        BOOST_FOREACH(const boost::shared_ptr<Trace> t, traces) {
+            boost::shared_ptr<view::DsoSignal> dsoSig;
             if (dsoSig = dynamic_pointer_cast<view::DsoSignal>(t)) {
                 if (dsoSig->get_vDialActive()) {
                     if (shift > 1.0)
@@ -366,7 +366,7 @@ void Header::mouseMoveEvent(QMouseEvent *event)
                     // Ensure the Trace is selected
                     sig->select(true);
                 } else {
-                    shared_ptr<DsoSignal> dsoSig;
+                    boost::shared_ptr<DsoSignal> dsoSig;
                     if (dsoSig = dynamic_pointer_cast<DsoSignal>(sig)) {
                         dsoSig->set_zeroPos(y);
                         dsoSig->select(false);

--- a/DSLogic-gui/pv/view/logicsignal.cpp
+++ b/DSLogic-gui/pv/view/logicsignal.cpp
@@ -85,12 +85,12 @@ const sr_channel* LogicSignal::probe() const
     return _probe;
 }
 
-shared_ptr<pv::data::SignalData> LogicSignal::data() const
+boost::shared_ptr<pv::data::SignalData> LogicSignal::data() const
 {
     return _data;
 }
 
-shared_ptr<pv::data::Logic> LogicSignal::logic_data() const
+boost::shared_ptr<pv::data::Logic> LogicSignal::logic_data() const
 {
     return _data;
 }

--- a/DSLogic-gui/pv/view/view.cpp
+++ b/DSLogic-gui/pv/view/view.cpp
@@ -186,9 +186,9 @@ void View::zoom(double steps, int offset)
             _scale *= pow(3.0/2.0, -steps);
             _scale = max(min(_scale, _maxscale), _minscale);
         }else {
-            const vector< shared_ptr<Signal> > sigs(_session.get_signals());
-            BOOST_FOREACH(const shared_ptr<Signal> s, sigs) {
-                shared_ptr<DsoSignal> dsoSig;
+            const vector< boost::shared_ptr<Signal> > sigs(_session.get_signals());
+            BOOST_FOREACH(const boost::shared_ptr<Signal> s, sigs) {
+                boost::shared_ptr<DsoSignal> dsoSig;
                 if (dsoSig = dynamic_pointer_cast<DsoSignal>(s)) {
                     if(steps > 0.5)
                         dsoSig->go_hDialPre();
@@ -244,19 +244,19 @@ void View::set_preScale_preOffset()
     set_scale_offset(_preScale, _preOffset);
 }
 
-vector< shared_ptr<Trace> > View::get_traces() const
+vector< boost::shared_ptr<Trace> > View::get_traces() const
 {
-    const vector< shared_ptr<Signal> > sigs(_session.get_signals());
+    const vector< boost::shared_ptr<Signal> > sigs(_session.get_signals());
 #ifdef ENABLE_DECODE
-    const vector< shared_ptr<DecodeTrace> > decode_sigs(
+    const vector< boost::shared_ptr<DecodeTrace> > decode_sigs(
         _session.get_decode_signals());
-    vector< shared_ptr<Trace> > traces(
+    vector< boost::shared_ptr<Trace> > traces(
         sigs.size() + decode_sigs.size());
 #else
-    vector< shared_ptr<Trace> > traces(sigs.size());
+    vector< boost::shared_ptr<Trace> > traces(sigs.size());
 #endif
 
-    vector< shared_ptr<Trace> >::iterator i = traces.begin();
+    vector< boost::shared_ptr<Trace> >::iterator i = traces.begin();
     i = copy(sigs.begin(), sigs.end(), i);
 #ifdef ENABLE_DECODE
     i = copy(decode_sigs.begin(), decode_sigs.end(), i);
@@ -266,8 +266,8 @@ vector< shared_ptr<Trace> > View::get_traces() const
     return traces;
 }
 
-bool View::compare_trace_v_offsets(const shared_ptr<Trace> &a,
-    const shared_ptr<Trace> &b)
+bool View::compare_trace_v_offsets(const boost::shared_ptr<Trace> &a,
+    const boost::shared_ptr<Trace> &b)
 {
     assert(a);
     assert(b);
@@ -350,14 +350,14 @@ const QPointF& View::hover_point() const
 
 void View::normalize_layout()
 {
-    const vector< shared_ptr<Trace> > traces(get_traces());
+    const vector< boost::shared_ptr<Trace> > traces(get_traces());
 
 	int v_min = INT_MAX;
-    BOOST_FOREACH(const shared_ptr<Trace> t, traces)
+    BOOST_FOREACH(const boost::shared_ptr<Trace> t, traces)
         v_min = min(t->get_v_offset(), v_min);
 
 	const int delta = -min(v_min, 0);
-    BOOST_FOREACH(shared_ptr<Trace> t, traces)
+    BOOST_FOREACH(boost::shared_ptr<Trace> t, traces)
         t->set_v_offset(t->get_v_offset() + delta);
 
 	verticalScrollBar()->setSliderPosition(_v_offset + delta);
@@ -377,7 +377,7 @@ int View::get_signalHeight()
 
 void View::get_scroll_layout(double &length, double &offset) const
 {
-    const set< shared_ptr<data::SignalData> > data_set = _session.get_data();
+    const set< boost::shared_ptr<data::SignalData> > data_set = _session.get_data();
     if (data_set.empty())
 		return;
 
@@ -445,8 +445,8 @@ void View::update_scale()
 void View::signals_changed()
 {
     int total_rows = 0;
-    const vector< shared_ptr<Trace> > traces(get_traces());
-    BOOST_FOREACH(const shared_ptr<Trace> t, traces)
+    const vector< boost::shared_ptr<Trace> > traces(get_traces());
+    BOOST_FOREACH(const boost::shared_ptr<Trace> t, traces)
     {
         assert(t);
         if (dynamic_pointer_cast<DsoSignal>(t) ||
@@ -461,7 +461,7 @@ void View::signals_changed()
     _signalHeight = (int)((height <= 0) ? 1 : height);
     _spanY = _signalHeight + 2 * SignalMargin;
     int next_v_offset = SignalMargin;
-    BOOST_FOREACH(shared_ptr<Trace> t, traces) {
+    BOOST_FOREACH(boost::shared_ptr<Trace> t, traces) {
         t->set_view(this);
         const double traceHeight = _signalHeight*t->rows_size();
         t->set_signalHeight((int)traceHeight);
@@ -529,9 +529,9 @@ int View::headerWidth()
     QFont font = QApplication::font();
     QFontMetrics fm(font);
 
-    const vector< shared_ptr<Trace> > traces(get_traces());
+    const vector< boost::shared_ptr<Trace> > traces(get_traces());
     if (!traces.empty()){
-        BOOST_FOREACH(const shared_ptr<Trace> t, traces) {
+        BOOST_FOREACH(const boost::shared_ptr<Trace> t, traces) {
             maxNameWidth = max(fm.boundingRect(t->get_name()).width(), maxNameWidth);
             maxLeftWidth = max(t->get_leftWidth(), maxLeftWidth);
             maxRightWidth = max(t->get_rightWidth(), maxRightWidth);
@@ -774,8 +774,8 @@ void View::on_state_changed(bool stop)
 int View::get_max_width()
 {
     int max_width = 0;
-    const vector< shared_ptr<Signal> > sigs(_session.get_signals());
-    BOOST_FOREACH(const shared_ptr<Signal> s, sigs) {
+    const vector< boost::shared_ptr<Signal> > sigs(_session.get_signals());
+    BOOST_FOREACH(const boost::shared_ptr<Signal> s, sigs) {
         max_width = max((double)max_width, s->get_view_rect().width());
     }
 

--- a/DSLogic-gui/pv/view/viewport.cpp
+++ b/DSLogic-gui/pv/view/viewport.cpp
@@ -77,8 +77,8 @@ int Viewport::get_total_height() const
 {
 	int h = 0;
 
-    const vector< shared_ptr<Trace> > traces(_view.get_traces());
-    BOOST_FOREACH(const shared_ptr<Trace> t, traces) {
+    const vector< boost::shared_ptr<Trace> > traces(_view.get_traces());
+    BOOST_FOREACH(const boost::shared_ptr<Trace> t, traces) {
         assert(t);
         h += (int)(t->get_signalHeight());
     }
@@ -103,8 +103,8 @@ void Viewport::paintEvent(QPaintEvent *event)
     QPainter p(this);
     style()->drawPrimitive(QStyle::PE_Widget, &o, &p, this);
 
-    const vector< shared_ptr<Trace> > traces(_view.get_traces());
-    BOOST_FOREACH(const shared_ptr<Trace> t, traces)
+    const vector< boost::shared_ptr<Trace> > traces(_view.get_traces());
+    BOOST_FOREACH(const boost::shared_ptr<Trace> t, traces)
     {
         assert(t);
         t->paint_back(p, 0, width());
@@ -129,7 +129,7 @@ void Viewport::paintEvent(QPaintEvent *event)
         paintSignals(p);
     }
 
-    BOOST_FOREACH(const shared_ptr<Trace> t, traces)
+    BOOST_FOREACH(const boost::shared_ptr<Trace> t, traces)
     {
         assert(t);
         if (t->enabled())
@@ -145,7 +145,7 @@ void Viewport::paintEvent(QPaintEvent *event)
 
 void Viewport::paintSignals(QPainter &p)
 {
-    const vector< shared_ptr<Trace> > traces(_view.get_traces());
+    const vector< boost::shared_ptr<Trace> > traces(_view.get_traces());
     if (_view.scale() != _curScale ||
         _view.offset() != _curOffset ||
         _view.get_signalHeight() != _curSignalHeight ||
@@ -159,7 +159,7 @@ void Viewport::paintSignals(QPainter &p)
         QPainter dbp(&pixmap);
         dbp.initFrom(this);
         p.setRenderHint(QPainter::Antialiasing, false);
-        BOOST_FOREACH(const shared_ptr<Trace> t, traces)
+        BOOST_FOREACH(const boost::shared_ptr<Trace> t, traces)
         {
             assert(t);
             if (t->enabled())
@@ -357,10 +357,10 @@ void Viewport::mousePressEvent(QMouseEvent *event)
 //            _zoom_rect_visible = true;
 //        }
 
-        const vector< shared_ptr<Signal> > sigs(_view.session().get_signals());
-        BOOST_FOREACH(const shared_ptr<Signal> s, sigs) {
+        const vector< boost::shared_ptr<Signal> > sigs(_view.session().get_signals());
+        BOOST_FOREACH(const boost::shared_ptr<Signal> s, sigs) {
             assert(s);
-            shared_ptr<DsoSignal> dsoSig;
+            boost::shared_ptr<DsoSignal> dsoSig;
             if ((dsoSig = dynamic_pointer_cast<DsoSignal>(s)) &&
                  dsoSig->get_trig_rect(0, width()).contains(_mouse_point)) {
                 _drag_sig = s;
@@ -383,7 +383,7 @@ void Viewport::mouseMoveEvent(QMouseEvent *event)
 
     if (event->buttons() & Qt::LeftButton) {
         if (_drag_sig) {
-            shared_ptr<view::DsoSignal> dsoSig;
+            boost::shared_ptr<view::DsoSignal> dsoSig;
             if (dsoSig = dynamic_pointer_cast<view::DsoSignal>(_drag_sig))
                 dsoSig->set_trig_vpos(_mouse_point.y());
         } else {


### PR DESCRIPTION
Fixing shared_ptr that is ambigious under c++11 compilers so that the GUI can compiles under OS X.
