### PR TITLE
Make building under Qt5 work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,14 +31,15 @@ Makefile.in
 configure
 aclocal.m4
 
-DSLogic-gui/ui_*.h
-DSLogic-gui/DSLogic
-DSLogic-gui/install_manifest.txt
+DSView/ui_*.h
+DSView/DSView
+DSView/install_manifest.txt
+DSView/qrc_DSView.cpp
 
-moc_*.cxx
-moc_*.cxx_parameters
+moc_*.cpp
+moc_*.cpp_parameters
 
-libsigrok4DSLogic/version.h
+libsigrok4DSL/version.h
 
 libusbx-1.0.18/doc/doxygen.cfg
 libusbx-1.0.18/m4/

--- a/DSView/main.cpp
+++ b/DSView/main.cpp
@@ -30,7 +30,7 @@
 
 #include <getopt.h>
 
-#include <QtGui/QApplication>
+#include <QApplication>
 #include <QDebug>
 #include <QFile>
 #include <QDir>

--- a/DSView/pv/devicemanager.cpp
+++ b/DSView/pv/devicemanager.cpp
@@ -31,7 +31,7 @@
 #include <stdexcept>
 #include <string>
 
-#include <QtGui/QApplication>
+#include <QApplication>
 #include <QObject>
 #include <QDebug>
 #include <QDir>

--- a/DSView/pv/mainwindow.cpp
+++ b/DSView/pv/mainwindow.cpp
@@ -225,8 +225,7 @@ void MainWindow::setup_ui()
 	// Set the title
     QString title = QApplication::applicationName()+" v"+QApplication::applicationVersion();
     std::string std_title = title.toStdString();
-    setWindowTitle(QApplication::translate("MainWindow", std_title.c_str(), 0,
-		QApplication::UnicodeUTF8));
+    setWindowTitle(QApplication::translate("MainWindow", std_title.c_str(), 0));
 
 	// Setup _session events
 	connect(&_session, SIGNAL(capture_state_changed(int)), this,
@@ -522,7 +521,7 @@ void MainWindow::on_screenShot()
                        tr("%1 Files (*.%2);;All Files (*)")
                        .arg(format.toUpper()).arg(format));
     if (!fileName.isEmpty())
-        pixmap.save(fileName, format.toAscii());
+        pixmap.save(fileName, format.toLatin1());
 }
 
 void MainWindow::on_save()

--- a/DSView/pv/toolbars/filebar.cpp
+++ b/DSView/pv/toolbars/filebar.cpp
@@ -47,8 +47,7 @@ FileBar::FileBar(SigSession &session, QWidget *parent) :
     setMovable(false);
 
     _action_open = new QAction(this);
-    _action_open->setText(QApplication::translate(
-        "File", "&Open...", 0, QApplication::UnicodeUTF8));
+    _action_open->setText(QApplication::translate("File", "&Open...", 0));
     _action_open->setIcon(QIcon::fromTheme("file",
         QIcon(":/icons/open.png")));
     _action_open->setObjectName(QString::fromUtf8("actionOpen"));
@@ -56,8 +55,7 @@ FileBar::FileBar(SigSession &session, QWidget *parent) :
     connect(_action_open, SIGNAL(triggered()), this, SLOT(on_actionOpen_triggered()));
 
     _action_save = new QAction(this);
-    _action_save->setText(QApplication::translate(
-        "File", "&Save...", 0, QApplication::UnicodeUTF8));
+    _action_save->setText(QApplication::translate("File", "&Save...", 0));
     _action_save->setIcon(QIcon::fromTheme("file",
         QIcon(":/icons/save.png")));
     _action_save->setObjectName(QString::fromUtf8("actionSave"));
@@ -65,8 +63,7 @@ FileBar::FileBar(SigSession &session, QWidget *parent) :
     connect(_action_save, SIGNAL(triggered()), this, SLOT(on_actionSave_triggered()));
 
     _action_capture = new QAction(this);
-    _action_capture->setText(QApplication::translate(
-        "File", "&Capture...", 0, QApplication::UnicodeUTF8));
+    _action_capture->setText(QApplication::translate("File", "&Capture...", 0));
     _action_capture->setIcon(QIcon::fromTheme("file",
         QIcon(":/icons/capture.png")));
     _action_capture->setObjectName(QString::fromUtf8("actionCapture"));

--- a/DSView/pv/toolbars/logobar.cpp
+++ b/DSView/pv/toolbars/logobar.cpp
@@ -46,8 +46,7 @@ LogoBar::LogoBar(SigSession &session, QWidget *parent) :
     setMovable(false);
 
     _about = new QAction(this);
-    _about->setText(QApplication::translate(
-        "File", "&About...", 0, QApplication::UnicodeUTF8));
+    _about->setText(QApplication::translate("File", "&About...", 0));
     _about->setIcon(QIcon::fromTheme("file",
         QIcon(":/icons/about.png")));
     _about->setObjectName(QString::fromUtf8("actionAbout"));
@@ -55,8 +54,7 @@ LogoBar::LogoBar(SigSession &session, QWidget *parent) :
     connect(_about, SIGNAL(triggered()), this, SLOT(on_actionAbout_triggered()));
 
     _wiki = new QAction(this);
-    _wiki->setText(QApplication::translate(
-        "File", "&Wiki", 0, QApplication::UnicodeUTF8));
+    _wiki->setText(QApplication::translate("File", "&Wiki", 0));
     _wiki->setIcon(QIcon::fromTheme("file",
         QIcon(":/icons/wiki.png")));
     _wiki->setObjectName(QString::fromUtf8("actionWiki"));

--- a/DSView/pv/view/view.cpp
+++ b/DSView/pv/view/view.cpp
@@ -27,7 +27,7 @@
 
 #include <boost/foreach.hpp>
 
-#include <QtGui/QApplication>
+#include <QApplication>
 #include <QEvent>
 #include <QMouseEvent>
 #include <QScrollBar>


### PR DESCRIPTION
The first patch makes changes to allow us to build under Qt5. (Verified on Debian Sid).
They might need to be tweaked if you still wants to be able to build under Qt4 (I don't have a Qt4 environment near me).

The second patch updates the .gitignore file to handle the renaming of DSLogic to DSView.