### PR TITLE
Remove some compilation warnings on linux

### DIFF
--- a/DSView/pv/data/dsosnapshot.cpp
+++ b/DSView/pv/data/dsosnapshot.cpp
@@ -237,9 +237,8 @@ void DsoSnapshot::append_payload_to_envelope_levels(bool header)
     _envelope_done = true;
 }
 
-double DsoSnapshot::cal_vrms(double zero_off, int index) const
+double DsoSnapshot::cal_vrms(double zero_off, unsigned int index) const
 {
-    assert(index >= 0);
     assert(index < _channel_num);
 
     // root-meam-squart value
@@ -272,9 +271,8 @@ double DsoSnapshot::cal_vrms(double zero_off, int index) const
     return vrms;
 }
 
-double DsoSnapshot::cal_vmean(int index) const
+double DsoSnapshot::cal_vmean(unsigned int index) const
 {
-    assert(index >= 0);
     assert(index < _channel_num);
 
     // mean value

--- a/DSView/pv/data/dsosnapshot.h
+++ b/DSView/pv/data/dsosnapshot.h
@@ -84,8 +84,8 @@ public:
 
     void enable_envelope(bool enable);
 
-    double cal_vrms(double zero_off, int index) const;
-    double cal_vmean(int index) const;
+    double cal_vrms(double zero_off, unsigned int index) const;
+    double cal_vmean(unsigned int index) const;
 
 private:
 	void reallocate_envelope(Envelope &l);

--- a/DSView/pv/dock/protocoldock.cpp
+++ b/DSView/pv/dock/protocoldock.cpp
@@ -105,7 +105,7 @@ void ProtocolDock::paintEvent(QPaintEvent *)
 {
      QStyleOption opt;
      opt.init(this);
-     QPainter p(this);
+     QPainter p(this->viewport());
      style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
 }
 


### PR DESCRIPTION
This commit aim to remove some compilation warnings caused by comparison between "integers" and "unsigned integers".