### PR TITLE
dsldial.cpp: Include math.h for sqrt()

### DIFF
--- a/DSView/pv/view/dsldial.cpp
+++ b/DSView/pv/view/dsldial.cpp
@@ -1,6 +1,7 @@
 #include "dsldial.h"
 
-#include <assert.h>
+#include <cassert>
+#include <cmath>
 
 namespace pv {
 namespace view {


### PR DESCRIPTION
I needed this to compile on Arch Linux.

(maybe on some platforms or QT versions the QT headers include math.h?)

Thanks for publishing DSView! I like my DSLogic a lot. Please consider working with the sigrok developers to upstream the rest of your support. If sigrok supported it fully then I would recommend DSLogic very loudly to everyone I could find. :)
