### PR TITLE
Use standard location for udev rules

### DIFF
--- a/DSView/CMakeLists.txt
+++ b/DSView/CMakeLists.txt
@@ -397,7 +397,7 @@ install(TARGETS ${PROJECT_NAME} DESTINATION bin/)
 install(DIRECTORY res DESTINATION share/${PROJECT_NAME})
 install(DIRECTORY ../libsigrokdecode4DSL/decoders DESTINATION share/${PROJECT_NAME})
 install(FILES icons/logo.png DESTINATION share/${PROJECT_NAME} RENAME logo.png)
-install(FILES DreamSourceLab.rules DESTINATION /etc/udev/rules.d/)
+install(FILES DreamSourceLab.rules DESTINATION /usr/lib/udev/rules.d/)
 install(FILES DSView.desktop DESTINATION /usr/share/applications/)
 
 #===============================================================================


### PR DESCRIPTION
/etc should be used for host-specific configuration only