### PR TITLE
Add (temporary?) libusb freeze fix from DSView issue #87

### DIFF
--- a/libsigrok4DSL/hardware/DSL/dslogic.c
+++ b/libsigrok4DSL/hardware/DSL/dslogic.c
@@ -2380,11 +2380,11 @@ static int receive_data(int fd, int revents, const struct sr_dev_inst *sdi)
     usb = sdi->conn;
 
     tv.tv_sec = tv.tv_usec = 0;
-    libusb_handle_events_timeout_completed(drvc->sr_ctx->libusb_ctx, &tv, &completed);
+    /* broken libusb_handle_events_timeout_completed(drvc->sr_ctx->libusb_ctx, &tv, &completed); */
 
     if (devc->status == DSL_FINISH) {
-        if (libusb_try_lock_events(drvc->sr_ctx->libusb_ctx) == 0) {
-            if (libusb_event_handling_ok(drvc->sr_ctx->libusb_ctx)) {
+        /* broken if (libusb_try_lock_events(drvc->sr_ctx->libusb_ctx) == 0) { */
+            /* broken if (libusb_event_handling_ok(drvc->sr_ctx->libusb_ctx)) { */
                 /* Stop GPIF acquisition */
                 usb = ((struct sr_dev_inst *)devc->cb_data)->conn;
                 if ((ret = command_stop_acquisition (usb->devhdl)) != SR_OK)
@@ -2393,9 +2393,9 @@ static int receive_data(int fd, int revents, const struct sr_dev_inst *sdi)
                     sr_info("%s: Sent acquisition stop command!", __func__);
 
                 remove_sources(devc);
-            }
-            libusb_unlock_events(drvc->sr_ctx->libusb_ctx);
-        }
+            /* } */
+            /* broken libusb_unlock_events(drvc->sr_ctx->libusb_ctx); */
+        /* } */
     }
 
     return TRUE;


### PR DESCRIPTION
Probably a temporary fix, but this allows the program to work on Fedora, Arch Linux, and possibly more. The current master works on Ubuntu, which uses an older version of libusb, so it seems that an update to libusb is what caused this issue. This fix by user @FuzzyCheese comments out some libusb code which seems to fix the problem for now. In terms of what changed, libusb removed some sort of functionality related to recursive something or other. I or someone else can look at this and find a better fix later.

This pull request does not break anything, as far as I know. It may need to be tested on Ubuntu, with the older verson of libusb.