### PR TITLE
fix compilation error on ARM platform. close #135

### DIFF
--- a/DSView/pv/dialogs/about.cpp
+++ b/DSView/pv/dialogs/about.cpp
@@ -44,6 +44,8 @@ About::About(QWidget *parent) :
         QString arch = "x64";
     #elif defined(__i386) || defined(_M_IX86)
         QString arch = "x86";
+    #elif defined(__arm__) || defined(_M_ARM)
+        QString arch = "arm";
     #endif
 
     QString version = tr("<font size=24>DSView %1 (%2)</font><br />")


### PR DESCRIPTION
Add ARM macros in `DSView/pv/dialogs/about.cpp` to fix compilation error on ARM platform, I tested on Tinker Board(armhf) and it should also work on Raspberry Pi.