### PR TITLE
dmx512 bug fix and nrf24l01 display enhancement

### DIFF
--- a/libsigrokdecode4DSL/decoders/dmx512/pd.py
+++ b/libsigrokdecode4DSL/decoders/dmx512/pd.py
@@ -79,17 +79,18 @@ class Decoder(srd.Decoder):
             # Seek for an interval with no state change with a length between
             # 88 and 1000000 us (BREAK).
             if self.state == 'FIND BREAK':
-                if self.run_bit == pins[0]:
-                    continue
-                runlen = (self.samplenum - self.run_start) * self.sample_usec
-                if runlen > 88 and runlen < 1000000:
-                    self.putr([1, ['Break']])
-                    self.bit_break = self.run_bit
-                    self.state = 'MARK MAB'
-                    self.channel = 0
-                elif runlen >= 1000000:
-                    # Error condition.
-                    self.putr([10, ['Invalid break length']])
+                if pins[0] == 0 or self.run_bit == 0:
+                    if self.run_bit == pins[0]:
+                        continue
+                    runlen = (self.samplenum - self.run_start) * self.sample_usec
+                    if runlen > 88 and runlen < 1000000:
+                        self.putr([1, ['Break']])
+                        self.bit_break = self.run_bit
+                        self.state = 'MARK MAB'
+                        self.channel = 0
+                    elif runlen >= 1000000:
+                        # Error condition.
+                        self.putr([10, ['Invalid break length']])
                 self.run_bit = pins[0]
                 self.run_start = self.samplenum
             # Directly following the BREAK is the MARK AFTER BREAK.

--- a/libsigrokdecode4DSL/decoders/nrf24l01/pd.py
+++ b/libsigrokdecode4DSL/decoders/nrf24l01/pd.py
@@ -71,6 +71,8 @@ class Decoder(srd.Decoder):
     options = (
         {'id': 'chip', 'desc': 'Chip type',
             'default': 'nrf24l01', 'values': ('nrf24l01', 'xn297')},
+        {'id': 'hex_display', 'desc': 'Display payload in Hex', 'default': 1,
+            'values': (0, 1)},
     )
     annotations = (
         # Sent from the host to the chip.
@@ -245,8 +247,8 @@ class Decoder(srd.Decoder):
                     return '\\x{:02X}'.format(b)
                 return c
 
-        data = ''.join([escape(b) for b in data])
-        text = '{} = "{}"'.format(label, data)
+        data = ' '.join([escape(b) for b in data])
+        text = '{} = "{}"'.format(label, data.strip())
         self.putp(pos, ann, text)
 
     def finish_command(self, pos):
@@ -260,15 +262,15 @@ class Decoder(srd.Decoder):
                                  self.dat, self.mosi_bytes())
         elif self.cmd == 'R_RX_PAYLOAD':
             self.decode_mb_data(pos, self.ann_rx,
-                                self.miso_bytes(), 'RX payload', False)
+                                self.miso_bytes(), 'RX payload', self.options['hex_display'])
         elif (self.cmd == 'W_TX_PAYLOAD' or
               self.cmd == 'W_TX_PAYLOAD_NOACK'):
             self.decode_mb_data(pos, self.ann_tx,
-                                self.mosi_bytes(), 'TX payload', False)
+                                self.mosi_bytes(), 'TX payload', self.options['hex_display'])
         elif self.cmd == 'W_ACK_PAYLOAD':
             lbl = 'ACK payload for pipe {}'.format(self.dat)
             self.decode_mb_data(pos, self.ann_tx,
-                                self.mosi_bytes(), lbl, False)
+                                self.mosi_bytes(), lbl, self.options['hex_display'])
         elif self.cmd == 'R_RX_PL_WID':
             msg = 'Payload width = {}'.format(self.mb[0][1])
             self.putp(pos, self.ann_reg, msg)


### PR DESCRIPTION
fix dmx512 "unable to find break" bug
原来的dmx512不能正常寻找break的位置，导致所有数据错位
enhance nrf24l01 payload hex display
增加了nrf24l01显示数据时显示十六进制。字符串的设定。原来的在显示传送数据的时候会强制显示字符串，调试非字符串数据时候很不方便。