### PR TITLE
Typo correction: Gitbub >> Github

### DIFF
--- a/DSView/pv/dialogs/about.cpp
+++ b/DSView/pv/dialogs/about.cpp
@@ -53,7 +53,7 @@ About::About(QWidget *parent) :
                       .arg(arch);
 
     QString url = tr("Website: <a href=\"%1\" style=\"color:#C0C0C0\">%1</a><br />"
-                     "Gitbub: <a href=\"%2\" style=\"color:#C0C0C0\">%2</a><br />"
+                     "Github: <a href=\"%2\" style=\"color:#C0C0C0\">%2</a><br />"
                      "<br /><br />")
                   .arg(QApplication::organizationDomain())
                   .arg("https://github.com/DreamSourceLab/DSView");


### PR DESCRIPTION
Correction of typo in the about dialog: gitbub >> github

![image](https://user-images.githubusercontent.com/1499454/56458825-a452bb00-638b-11e9-9593-160d686ed6e2.png)
