### PR TITLE
Added option to suppress start/stop bit annotation on UART decode

### DIFF
--- a/libsigrokdecode4DSL/decoders/0-uart/pd.py
+++ b/libsigrokdecode4DSL/decoders/0-uart/pd.py
@@ -102,6 +102,8 @@ class Decoder(srd.Decoder):
             'values': ('ascii', 'dec', 'hex', 'oct', 'bin')},
         {'id': 'invert', 'desc': 'Invert Signal?', 'default': 'no',
             'values': ('yes', 'no')},
+		{'id': 'anno_startstop', 'desc': 'Display Start/Stop?', 'default': 'no',
+            'values': ('yes', 'no')},
     )
     annotations = (
         ('108', 'data', 'data'),
@@ -119,7 +121,10 @@ class Decoder(srd.Decoder):
 
     def putx(self, data):
         s, halfbit = self.startsample, self.bit_width / 2.0
-        self.put(s - floor(halfbit), self.samplenum + ceil(halfbit), self.out_ann, data)
+        if self.options['anno_startstop'] == 'yes' :
+            self.put(s - floor(halfbit), self.samplenum + ceil(halfbit), self.out_ann, data)
+        else :
+            self.put(self.frame_start, self.samplenum + ceil(halfbit * (1+self.options['num_stop_bits'])), self.out_ann, data)
 
     def putg(self, data):
         s, halfbit = self.samplenum, self.bit_width / 2.0
@@ -189,7 +194,8 @@ class Decoder(srd.Decoder):
         self.datavalue = 0
         self.startsample = -1
 
-        self.putg([1, ['Start bit', 'Start', 'S']])
+        if self.options['anno_startstop'] == 'yes':
+            self.putg([1, ['Start bit', 'Start', 'S']])
 
         self.state = 'GET DATA BITS'
 
@@ -290,7 +296,8 @@ class Decoder(srd.Decoder):
             self.putg([5, ['Frame error', 'Frame err', 'FE']])
             self.frame_valid = False
 
-        self.putg([2, ['Stop bit', 'Stop', 'T']])
+        if self.options['anno_startstop'] == 'yes':
+            self.putg([2, ['Stop bit', 'Stop', 'T']])
 
         # Pass the complete UART frame to upper layers.
         es = self.samplenum + ceil(self.bit_width / 2.0)


### PR DESCRIPTION
This allows the decoded data value to expand and make it easier to examine longer packets while zoomed further out