### PR TITLE
fix compilation error on ARM64 and other platforms

### DIFF
--- a/DSView/pv/dialogs/about.cpp
+++ b/DSView/pv/dialogs/about.cpp
@@ -46,6 +46,10 @@ About::About(QWidget *parent) :
         QString arch = "x86";
     #elif defined(__arm__) || defined(_M_ARM)
         QString arch = "arm";
+    #elif defined(__aarch64__)
+        QString arch = "arm64";
+    #else
+        QString arch = "other";
     #endif
 
     QString version = tr("<font size=24>DSView %1 (%2)</font><br />")


### PR DESCRIPTION
Tested with ArchlinuxARM 64-bit.
### Before:
```
/home/redchenjs/.cache/yay/dsview-git/src/DSView/DSView/pv/dialogs/about.cpp: 在构造函数「pv::dialogs::About::About(QWidget*)」中:
/home/redchenjs/.cache/yay/dsview-git/src/DSView/DSView/pv/dialogs/about.cpp:53:28: 錯誤：「arch」 在此作用欄位中尚未宣告
                       .arg(arch);
                            ^~~~
make[2]: *** [CMakeFiles/DSView.dir/build.make:1057：CMakeFiles/DSView.dir/pv/dialogs/about.cpp.o] 错误 1
```
### After:
![Deepin 截圖_dde-desktop_20191026142742](https://user-images.githubusercontent.com/9910809/67615298-418c2180-f7fd-11e9-8bb8-e8fbce99546b.png)
