### PR TITLE
Remove unnecessary extern "C"s, fix build failures.

### DIFF
--- a/DSView/pv/data/decode/annotation.cpp
+++ b/DSView/pv/data/decode/annotation.cpp
@@ -19,9 +19,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
  */
 
-extern "C" {
 #include <libsigrokdecode4DSL/libsigrokdecode.h>
-}
 
 #include <vector>
 #include <assert.h>

--- a/DSView/pv/view/decodetrace.cpp
+++ b/DSView/pv/view/decodetrace.cpp
@@ -19,9 +19,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
  */
 
-extern "C" {
 #include <libsigrokdecode4DSL/libsigrokdecode.h>
-}
 
 #include <extdef.h>
 

--- a/DSView/pv/widgets/decodergroupbox.cpp
+++ b/DSView/pv/widgets/decodergroupbox.cpp
@@ -18,9 +18,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
  */
-extern "C" {
 #include <libsigrokdecode4DSL/libsigrokdecode.h>
-}
 
 #include "decodergroupbox.h"
 #include "../data/decoderstack.h"


### PR DESCRIPTION
A handful of files wrap `libsigrokdecode.h` in `extern "C"` which is unnecessary, because `libsigrokdecode.h` already correctly wraps its function declarations.

`libsigrokdecode.h` includes glib, and wrapping it in `extern "C"` causes build failures with modern versions of glib due to template usage by glib. This patch fixes that build failure.