### PR TITLE
Fix build issue from 'extern "C"'

### DIFF
--- a/DSView/pv/data/decode/annotation.cpp
+++ b/DSView/pv/data/decode/annotation.cpp
@@ -19,9 +19,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
  */
 
-extern "C" {
 #include <libsigrokdecode4DSL/libsigrokdecode.h>
-}
 
 #include <vector>
 #include <assert.h>

--- a/DSView/pv/view/decodetrace.cpp
+++ b/DSView/pv/view/decodetrace.cpp
@@ -19,9 +19,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
  */
 
-extern "C" {
 #include <libsigrokdecode4DSL/libsigrokdecode.h>
-}
 
 #include <extdef.h>
 

--- a/DSView/pv/widgets/decodergroupbox.cpp
+++ b/DSView/pv/widgets/decodergroupbox.cpp
@@ -18,9 +18,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
  */
-extern "C" {
 #include <libsigrokdecode4DSL/libsigrokdecode.h>
-}
 
 #include "decodergroupbox.h"
 #include "../data/decoderstack.h"


### PR DESCRIPTION
`libsigrokdecode.h` is already wrapped with 'extern "C"', if we wrap the header here again, compile will result in error: template with C linkage. Remove this statement here resolves the problem.