### PR TITLE
libsigrokdecode4DSL: Add missing Python runtime functions (Fix: #406)

### DIFF
--- a/libsigrokdecode4DSL/decoders/common/srdhelper/mod.py
+++ b/libsigrokdecode4DSL/decoders/common/srdhelper/mod.py
@@ -31,6 +31,20 @@ def bin2int(s: str):
 def bitpack(bits):
     return sum([b << i for i, b in enumerate(bits)])
 
+def bitpack_lsb(bits, idx=None):
+    '''Conversion from LSB first bit sequence to integer.'''
+    if idx is not None:
+        bits = [b[idx] for b in bits]
+    return bitpack(bits)
+
+def bitpack_msb(bits, idx=None):
+    '''Conversion from MSB first bit sequence to integer.'''
+    bits = bits[:]
+    if idx is not None:
+        bits = [b[idx] for b in bits]
+    bits.reverse()
+    return bitpack(bits)
+
 def bitunpack(num, minbits=0):
     res = []
     while num or minbits > 0:


### PR DESCRIPTION
After building and installing DSView from source, the application will fail to run with the error described in #406. 

There are two functions missing, which are defined upstream `libsigrokdecode` on `master` (`02aa01a` at this time): 
 - https://github.com/sigrokproject/libsigrokdecode/blob/02aa01ad5f05f2730309200abda0ac75d3721e1d/decoders/common/srdhelper/mod.py#L34-L46.