### PR TITLE
Drop OUTPUT_PYTHON from 0:UART

### DIFF
--- a/libsigrokdecode4DSL/decoders/0-uart/pd.py
+++ b/libsigrokdecode4DSL/decoders/0-uart/pd.py
@@ -22,30 +22,6 @@ import sigrokdecode as srd
 from common.srdhelper import bitpack
 from math import floor, ceil
 
-'''
-OUTPUT_PYTHON format:
-
-Packet:
-[<ptype>, <rxtx>, <pdata>]
-
-This is the list of <ptype>s and their respective <pdata> values:
- - 'STARTBIT': The data is the (integer) value of the start bit (0/1).
- - 'DATA': This is always a tuple containing two items:
-   - 1st item: the (integer) value of the UART data. Valid values
-     range from 0 to 511 (as the data can be up to 9 bits in size).
-   - 2nd item: the list of individual data bits and their ss/es numbers.
- - 'PARITYBIT': The data is the (integer) value of the parity bit (0/1).
- - 'STOPBIT': The data is the (integer) value of the stop bit (0 or 1).
- - 'INVALID STARTBIT': The data is the (integer) value of the start bit (0/1).
- - 'INVALID STOPBIT': The data is the (integer) value of the stop bit (0/1).
- - 'PARITY ERROR': The data is a tuple with two entries. The first one is
-   the expected parity value, the second is the actual parity value.
- - 'FRAME': The data is always a tuple containing two items: The (integer)
-   value of the UART data, and a boolean which reflects the validity of the
-   UART frame.
-
-'''
-
 # Given a parity type to check (odd, even, zero, one), the value of the
 # parity bit, the value of the data, and the length of the data (5-9 bits,
 # usually 8 bits) return True if the parity is correct, False otherwise.
@@ -81,7 +57,7 @@ class Decoder(srd.Decoder):
     desc = 'Asynchronous, serial bus.'
     license = 'gplv2+'
     inputs = ['logic']
-    outputs = ['uart']
+    outputs = []
     tags = ['Embedded/industrial']
     channels = (
         {'id': 'rxtx', 'type': 209, 'name': 'RX/TX', 'desc': 'UART transceive line'},


### PR DESCRIPTION
I'm not sure the rationale, but we have 2 UART decoders:

- `0:UART` says it outputs `uart`, documents it at `OUTPUT_PYTHON` but does **NOT** output anything.
  -  This means that stacked decoders receive nothing.
- `1:UART` says it outputs `uart`, documents it at `OUTPUT_PYTHON` and  **DOES** output it.

This PR removes the wrong declaration from `0:UART` so that people cant't attempt to stack decodes for the case where it does not work.

PS: I've cut a PR to add upstream uart decoder which does not have the issue above and supports setting RX & TX https://github.com/DreamSourceLab/DSView/pull/429. Perhaps the fix here is simply removing both problematic `0:UART` and `1:UART`.