### PR TITLE
improved save speed of session file

### DIFF
--- a/libsigrok4DSL/proto.h
+++ b/libsigrok4DSL/proto.h
@@ -105,8 +105,10 @@ SR_API int sr_session_start(void);
 SR_API int sr_session_run(void);
 SR_API int sr_session_stop(void);
 SR_API int sr_session_save_init(const char *filename, const char *metafile, const char *decfile, const char *sesfile);
-SR_API int sr_session_append(const char *filename, const unsigned char *buf,
+SR_API int sr_session_append_open(struct zip *archive, const char *filename);
+SR_API int sr_session_append(struct zip *archive, const char *filename, const unsigned char *buf,
         uint64_t size, int chunk_num, int index, int type, int version);
+SR_API int sr_session_close(struct zip *archive);
 SR_API int sr_session_source_add(int fd, int events, int timeout,
 		sr_receive_data_callback_t cb, const struct sr_dev_inst *sdi);
 SR_API int sr_session_source_add_pollfd(GPollFD *pollfd, int timeout,


### PR DESCRIPTION
main issue was in `sr_sessoin_append`, where it was opening and closing that zipfile every time, i moved this operation outside this function. It is not pretty solution, but it is fast solution.
I also had to modify `soresession.cpp` because it would abort saving when it left loop. i added dummy bytes to write and marked them written after closing zipfile