### PR TITLE
common/minizip/*: fix OF prototypes

### DIFF
--- a/common/minizip/ioapi.h
+++ b/common/minizip/ioapi.h
@@ -44,6 +44,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "zlib.h"
+#include "of.h"
 
 #if defined(USE_FILE32API)
 #define fopen64 fopen

--- a/common/minizip/mztools.h
+++ b/common/minizip/mztools.h
@@ -13,6 +13,7 @@ extern "C" {
 
 #ifndef _ZLIB_H
 #include "zlib.h"
+#include "of.h"
 #endif
 
 #include "unzip.h"

--- a/common/minizip/of.h
+++ b/common/minizip/of.h
@@ -1,0 +1,12 @@
+#ifndef _OF_H
+#define _OF_H
+
+#ifndef OF /* function prototypes */
+#  ifdef STDC
+#    define OF(args)  args
+#  else
+#    define OF(args)  ()
+#  endif
+#endif
+
+#endif /* _OF_H */

--- a/common/minizip/unzip.h
+++ b/common/minizip/unzip.h
@@ -49,6 +49,7 @@ extern "C" {
 
 #ifndef _ZLIB_H
 #include "zlib.h"
+#include "of.h"
 #endif
 
 #ifndef  _ZLIBIOAPI_H

--- a/common/minizip/zip.h
+++ b/common/minizip/zip.h
@@ -48,6 +48,7 @@ extern "C" {
 
 #ifndef _ZLIB_H
 #include "zlib.h"
+#include "of.h"
 #endif
 
 #ifndef _ZLIBIOAPI_H


### PR DESCRIPTION
Because the sys-libs/zlib header pollutes the macro namespace,
leading to build failures. Under the gentoo operating system,
the macro definition of OF becomes _Z_OF in zconf.h, but the
recently introduced minizip has introduced a large number of OF,
leading to build fail. Therefore, the prototypes of OF are added
so that they can be successfully built under various operating
systems.

Bug: https://bugs.gentoo.org/383179