### PR TITLE
Add QT6 missing dependencies

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -34,7 +34,7 @@ Debian/Ubuntu:
  	 	
    How to install qt on ubuntu?
    	qt5: qt5-default,qtbase5-dev
-   	qt6: qt6-base-dev,libQt6Svg*,libgl1-mesa-dev*
+   	qt6: qt6-base-dev,libQt6Svg*,libgl1-mesa-dev*,libxkbcommon-dev,libvulkan-dev
 
 Fedora (18, 19):
  $ sudo yum install git gcc g++ make cmake libtool pkgconfig glib2-devel \


### PR DESCRIPTION
This PR fixes `cmake .`'s errors in QT6 builds:

```sh
-- Could NOT find XKB (missing: XKB_LIBRARY XKB_INCLUDE_DIR) (Required is at least version "0.5.0")
-- Could NOT find WrapVulkanHeaders (missing: Vulkan_INCLUDE_DIR) 
-- Could NOT find XKB (missing: XKB_LIBRARY XKB_INCLUDE_DIR) (Required is at least version "0.5.0")
-- Could NOT find WrapVulkanHeaders (missing: Vulkan_INCLUDE_DIR) 
```