### PR TITLE
Install udev & .desktop to proper directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -662,16 +662,8 @@ install(FILES DSView/icons/logo.svg DESTINATION share/icons/hicolor/scalable/app
 install(FILES DSView/icons/logo.svg DESTINATION share/pixmaps RENAME dsview.svg)
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")	
-	install(FILES DSView/DSView.desktop DESTINATION /usr/share/applications RENAME dsview.desktop)
-	
-	if(IS_DIRECTORY /usr/lib/udev/rules.d)
-		install(FILES DSView/DreamSourceLab.rules DESTINATION /usr/lib/udev/rules.d RENAME 60-dreamsourcelab.rules)
-	elseif(IS_DIRECTORY /lib/udev/rules.d)
-		install(FILES DSView/DreamSourceLab.rules DESTINATION /lib/udev/rules.d RENAME 60-dreamsourcelab.rules)
-	elseif(IS_DIRECTORY /etc/udev/rules.d)
-		install(FILES DSView/DreamSourceLab.rules DESTINATION /etc/udev/rules.d RENAME 60-dreamsourcelab.rules)
-	endif()
-
+	install(FILES DSView/DSView.desktop DESTINATION share/applications RENAME dsview.desktop)
+	install(FILES DSView/DreamSourceLab.rules DESTINATION ${CMAKE_INSTALL_LIBDIR}/udev/rules.d RENAME 60-dreamsourcelab.rules)
 endif()
 
 install(FILES NEWS25 DESTINATION share/DSView RENAME NEWS25)


### PR DESCRIPTION
This makes it portable across linux distros without having to hardcode paths.