### PR TITLE
Update decoded data table on each new annotation

### DIFF
--- a/DSView/pv/data/decoderstack.cpp
+++ b/DSView/pv/data/decoderstack.cpp
@@ -818,6 +818,7 @@ void DecoderStack::annotation_callback(srd_proto_data *pdata, void *self)
 	// Add the annotation 
     if (!(*row_iter).second->push_annotation(a))
         d->_no_memory = true; 
+    d->new_annotation();
 }
  
 void DecoderStack::frame_ended()

--- a/DSView/pv/data/decoderstack.h
+++ b/DSView/pv/data/decoderstack.h
@@ -190,6 +190,7 @@ private:
 signals:
 	void new_decode_data();
     void decode_done();
+    void new_annotation();
   
 private: 
 	std::list<decode::Decoder*> _stack;

--- a/DSView/pv/dock/protocoldock.cpp
+++ b/DSView/pv/dock/protocoldock.cpp
@@ -417,7 +417,10 @@ bool ProtocolDock::add_protocol_by_id(QString id, bool silent, std::list<pv::dat
     // progress connection
     const auto &decode_sigs = _session->get_decode_signals();   
     protocol_updated();
-    connect(decode_sigs.back(), SIGNAL(decoded_progress(int)), this, SLOT(decoded_progress(int)));
+    connect(decode_sigs.back(), SIGNAL(decoded_progress()), this, SLOT(decoded_progress()));
+
+    const auto _decoder_stack = _session->get_decoder_model()->getDecoderStack();
+    connect(_decoder_stack, SIGNAL(new_annotation()), this, SLOT(update_model()));
 
     return true;
 }
@@ -451,7 +454,7 @@ void ProtocolDock::del_all_protocol()
     }
 }
 
-void ProtocolDock::decoded_progress(int progress)
+void ProtocolDock::decoded_progress()
 {
     const auto &decode_sigs = _session->get_decode_signals();
     unsigned int index = 0;
@@ -477,10 +480,8 @@ void ProtocolDock::decoded_progress(int progress)
         index++;
     }
 
-    if (progress == 0 || progress % 10 == 1){
         update_model();
     }  
-}
 
 void ProtocolDock::set_model()
 {
@@ -1017,7 +1018,7 @@ bool ProtocolDock::protocol_sort_callback(const DecoderInfoItem *o1, const Decod
 
  void ProtocolDock::reset_view()
  {
-    decoded_progress(0);
+    decoded_progress();
     update();
  }
 

--- a/DSView/pv/dock/protocoldock.h
+++ b/DSView/pv/dock/protocoldock.h
@@ -128,7 +128,7 @@ public slots:
 private slots:
     void on_add_protocol(); 
     void on_del_all_protocol();
-    void decoded_progress(int progress);
+    void decoded_progress();
     void set_model();   
     void export_table_view();
     void nav_table_view();

--- a/DSView/pv/view/decodetrace.cpp
+++ b/DSView/pv/view/decodetrace.cpp
@@ -547,7 +547,7 @@ void DecodeTrace::draw_unshown_row(QPainter &p, int y, int h, int left,
 
 void DecodeTrace::on_new_decode_data()
 {
-    decoded_progress(_decoder_stack->get_progress());
+    decoded_progress();
 
     if (_view && _view->session().is_stopped_status())
         _view->data_updated();

--- a/DSView/pv/view/decodetrace.h
+++ b/DSView/pv/view/decodetrace.h
@@ -171,7 +171,7 @@ private:
  
 
 signals:
-    void decoded_progress(int progress);
+    void decoded_progress();
 
 private slots:
 	void on_new_decode_data();   


### PR DESCRIPTION
Currently, the decoded data table only gets updated on 10% steps of the overall capture time. This slows down updating of the table on long running sessions, making realtime inspection of e.g. I2C communication impossible.

Instead of relying on the capture progress, bind the table update to the annotation generation.

Fixes: #728