### PR TITLE
Implemented sample display on logic signals

### DIFF
--- a/DSView/pv/view/logicsignal.h
+++ b/DSView/pv/view/logicsignal.h
@@ -122,6 +122,8 @@ private:
 
     void paint_mid_align(QPainter &p, int left, int right, QColor fore, QColor back, uint64_t end_align_sample);
 
+    void paint_sample(QPainter &p, double x, double y);
+
 private:
 	pv::data::LogicSnapshot* _data;
     std::vector< std::pair<uint16_t, bool> > _cur_edges;


### PR DESCRIPTION
This solves #761 regarding logic signals.

When zoomed in enough to display single samples, the samples are visualized.