### PR TITLE
Add a ScrollSpeed option

### DIFF
--- a/DSView/pv/config/appconfig.cpp
+++ b/DSView/pv/config/appconfig.cpp
@@ -107,6 +107,14 @@ static void setFiled(const char *key, QSettings &st, float f)
     st.setValue(key, f);
 }
 
+static void getFiled(const char *key, QSettings &st, double &f, double dv) {
+    f = st.value(key, dv).toDouble();
+}
+
+static void setFiled(const char *key, QSettings &st, double f) {
+    st.setValue(key, f);
+}
+
 ///------ app
 static void _loadApp(AppOptions &o, QSettings &st)
 {
@@ -123,6 +131,7 @@ static void _loadApp(AppOptions &o, QSettings &st)
     getFiled("swapBackBufferAlways", st, o.swapBackBufferAlways, false);
     getFiled("fontSize", st, o.fontSize, 9.0);
     getFiled("autoScrollLatestData", st, o.autoScrollLatestData, true);
+    getFiled("scrollSpeed", st, o.scrollSpeed, 1.00);
     getFiled("version", st, o.version, 1);
 
     o.warnofMultiTrig = true;
@@ -160,6 +169,7 @@ static void _saveApp(AppOptions &o, QSettings &st)
     setFiled("swapBackBufferAlways", st, o.swapBackBufferAlways);
     setFiled("fontSize", st, o.fontSize);
     setFiled("autoScrollLatestData", st, o.autoScrollLatestData);
+    setFiled("scrollSpeed", st, o.scrollSpeed);
     setFiled("version", st, APP_CONFIG_VERSION);
 
     QString fmt =  FormatArrayToString(o.m_protocolFormats);

--- a/DSView/pv/config/appconfig.h
+++ b/DSView/pv/config/appconfig.h
@@ -72,6 +72,7 @@ struct AppOptions
     bool  swapBackBufferAlways;
     bool  autoScrollLatestData;
     float fontSize;
+    double scrollSpeed;
 
     std::vector<StringPair> m_protocolFormats;
 };

--- a/DSView/pv/dialogs/applicationpardlg.cpp
+++ b/DSView/pv/dialogs/applicationpardlg.cpp
@@ -31,6 +31,7 @@
 #include <QLabel>
 #include <vector>
 #include <QGridLayout>
+#include <QDoubleSpinBox>
 
 #include "../config/appconfig.h"
 #include "../ui/langresource.h"
@@ -104,18 +105,17 @@ void ApplicationParamDlg::bind_font_size_list(QComboBox *box, float size)
     box->setCurrentIndex(selDex);
 }
 
-bool ApplicationParamDlg::ShowDlg(QWidget *parent)
-{
+bool ApplicationParamDlg::ShowDlg(QWidget *parent) {
     DSDialog dlg(parent, true, true);
     dlg.setTitle(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_DISPLAY_OPTIONS), "Display options"));
     dlg.setMinimumSize(300, 230);
 
     QVBoxLayout *lay = new QVBoxLayout();
-    lay->setContentsMargins(0,10,0,20);
+    lay->setContentsMargins(0, 10, 0, 20);
     lay->setSpacing(8);
 
-    //show config
-    AppConfig &app = AppConfig::Instance(); 
+    // show config
+    AppConfig &app = AppConfig::Instance();
 
     QCheckBox *ck_quickScroll = new QCheckBox();
     ck_quickScroll->setChecked(app.appOptions.quickScroll);
@@ -135,93 +135,104 @@ bool ApplicationParamDlg::ShowDlg(QWidget *parent)
     QComboBox *ftCbSize = new DsComboBox();
     ftCbSize->setFixedWidth(50);
     bind_font_size_list(ftCbSize, app.appOptions.fontSize);
-   
+
+    QDoubleSpinBox *sb_scrollSpeed = new QDoubleSpinBox();
+    sb_scrollSpeed->setRange(0.01, 10.0);
+    sb_scrollSpeed->setSingleStep(0.05);
+    sb_scrollSpeed->setValue(app.appOptions.scrollSpeed);
+
     // Logic group
     QGroupBox *logicGroup = new QGroupBox(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_GROUP_LOGIC), "Logic"));
     QGridLayout *logicLay = new QGridLayout();
-    logicLay->setContentsMargins(10,15,15,10);
+    logicLay->setContentsMargins(10, 15, 15, 10);
     logicLay->setAlignment(Qt::AlignTop | Qt::AlignLeft);
     logicGroup->setLayout(logicLay);
-    logicLay->addWidget(new QLabel(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_QUICK_SCROLL), "Quick scroll")), 0, 0, Qt::AlignLeft); 
+    logicLay->addWidget(new QLabel(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_QUICK_SCROLL), "Quick scroll")), 0, 0, Qt::AlignLeft);
     logicLay->addWidget(ck_quickScroll, 0, 1, Qt::AlignRight);
-    logicLay->addWidget(new QLabel(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_USE_ABORT_DATA_REPEAT), "Used abort data")), 1, 0, Qt::AlignLeft); 
+    logicLay->addWidget(new QLabel(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_USE_ABORT_DATA_REPEAT), "Used abort data")), 1, 0, Qt::AlignLeft);
     logicLay->addWidget(ck_abortData, 1, 1, Qt::AlignRight);
-    logicLay->addWidget(new QLabel(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_AUTO_SCROLL_LATEAST_DATA), "Auto scoll latest")), 2, 0, Qt::AlignLeft); 
+    logicLay->addWidget(new QLabel(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_AUTO_SCROLL_LATEAST_DATA), "Auto scroll latest")), 2, 0, Qt::AlignLeft);
     logicLay->addWidget(ck_autoScrollLatestData, 2, 1, Qt::AlignRight);
     lay->addWidget(logicGroup);
 
-    //Scope group
+    // Scope group
     QGroupBox *dsoGroup = new QGroupBox(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_GROUP_DSO), "Scope"));
     QGridLayout *dsoLay = new QGridLayout();
-    dsoLay->setContentsMargins(10,15,15,10);
+    dsoLay->setContentsMargins(10, 15, 15, 10);
     dsoLay->setAlignment(Qt::AlignTop | Qt::AlignLeft);
     dsoGroup->setLayout(dsoLay);
-    dsoLay->addWidget(new QLabel(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_TRIG_DISPLAY_MIDDLE), "Tig pos in middle")), 0, 0, Qt::AlignLeft);
+    dsoLay->addWidget(new QLabel(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_TRIG_DISPLAY_MIDDLE), "Trig pos in middle")), 0, 0, Qt::AlignLeft);
     dsoLay->addWidget(ck_trigInMid, 0, 1, Qt::AlignRight);
     lay->addWidget(dsoGroup);
 
-    //UI
+    // UI
     QGroupBox *uiGroup = new QGroupBox(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_GROUP_UI), "UI"));
     QGridLayout *uiLay = new QGridLayout();
-    uiLay->setContentsMargins(10,15,15,10);
+    uiLay->setContentsMargins(10, 15, 15, 10);
     uiLay->setAlignment(Qt::AlignTop | Qt::AlignLeft);
     uiGroup->setLayout(uiLay);
     uiLay->addWidget(new QLabel(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_DISPLAY_PROFILE_IN_BAR), "Profile in bar")), 0, 0, Qt::AlignLeft);
     uiLay->addWidget(ck_profileBar, 0, 1, Qt::AlignRight);
     uiLay->addWidget(new QLabel(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_FONT_SIZE), "Font size")), 1, 0, Qt::AlignLeft);
     uiLay->addWidget(ftCbSize, 1, 1, Qt::AlignRight);
+    uiLay->addWidget(new QLabel(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_SCROLL_SPEED), "Scroll speed")), 2, 0, Qt::AlignLeft);
+    uiLay->addWidget(sb_scrollSpeed, 2, 1, Qt::AlignRight);
     lay->addWidget(uiGroup);
 
-    dlg.layout()->addLayout(lay);      
+    dlg.layout()->addLayout(lay);
     dlg.exec();
     bool ret = dlg.IsClickYes();
 
-    //save config
-    if (ret){
-
+    // save config
+    if (ret) {
         bool bAppChanged = false;
         bool bFontChanged = false;
         float fSize = ftCbSize->currentText().toFloat();
+        float scrollSpeed = sb_scrollSpeed->value();
 
-        if (app.appOptions.quickScroll != ck_quickScroll->isChecked()){
+        if (app.appOptions.quickScroll != ck_quickScroll->isChecked()) {
             app.appOptions.quickScroll = ck_quickScroll->isChecked();
             bAppChanged = true;
-        }       
-        if (app.appOptions.trigPosDisplayInMid != ck_trigInMid->isChecked()){
+        }
+        if (app.appOptions.trigPosDisplayInMid != ck_trigInMid->isChecked()) {
             app.appOptions.trigPosDisplayInMid = ck_trigInMid->isChecked();
             bAppChanged = true;
         }
-        if (app.appOptions.displayProfileInBar != ck_profileBar->isChecked()){
+        if (app.appOptions.displayProfileInBar != ck_profileBar->isChecked()) {
             app.appOptions.displayProfileInBar = ck_profileBar->isChecked();
             bAppChanged = true;
         }
-        if (app.appOptions.swapBackBufferAlways != ck_abortData->isChecked()){
+        if (app.appOptions.swapBackBufferAlways != ck_abortData->isChecked()) {
             app.appOptions.swapBackBufferAlways = ck_abortData->isChecked();
             bAppChanged = true;
-        }        
-        if (app.appOptions.fontSize != fSize){
+        }
+        if (app.appOptions.fontSize != fSize) {
             app.appOptions.fontSize = fSize;
             bFontChanged = true;
         }
-        if (app.appOptions.autoScrollLatestData != ck_autoScrollLatestData->isChecked()){
+        if (app.appOptions.autoScrollLatestData != ck_autoScrollLatestData->isChecked()) {
             app.appOptions.autoScrollLatestData = ck_autoScrollLatestData->isChecked();
             bAppChanged = true;
         }
- 
-        if (bAppChanged){
+        if (app.appOptions.scrollSpeed != scrollSpeed) {
+            app.appOptions.scrollSpeed = scrollSpeed;
+            bAppChanged = true;
+        }
+
+        if (bAppChanged) {
             app.SaveApp();
             AppControl::Instance()->GetSession()->broadcast_msg(DSV_MSG_APP_OPTIONS_CHANGED);
         }
-        
-        if (bFontChanged){
-            if (!bAppChanged){
+
+        if (bFontChanged) {
+            if (!bAppChanged) {
                 app.SaveApp();
             }
             AppControl::Instance()->GetSession()->broadcast_msg(DSV_MSG_FONT_OPTIONS_CHANGED);
         }
     }
-   
-   return ret;
+
+    return ret;
 }
  
 

--- a/DSView/pv/view/viewport.cpp
+++ b/DSView/pv/view/viewport.cpp
@@ -1356,11 +1356,11 @@ void Viewport::wheelEvent(QWheelEvent *event)
     delta = event->delta();
     isVertical = event->orientation() == Qt::Vertical;
 #endif
-
-    double zoom_scale = delta / 80;
+    double divisor_zoom = 16;
+    double zoom_scale = delta / 80 / divisor_zoom;
 
     if (ABS_VAL(delta) <= 80){
-        zoom_scale = delta > 0 ? 1.5 : -1.5;
+        zoom_scale = delta > 0 ? 1.5 / divisor_zoom : -1.5 / divisor_zoom;
     }
 
     if (_type == FFT_VIEW)

--- a/DSView/pv/view/viewport.cpp
+++ b/DSView/pv/view/viewport.cpp
@@ -1356,11 +1356,12 @@ void Viewport::wheelEvent(QWheelEvent *event)
     delta = event->delta();
     isVertical = event->orientation() == Qt::Vertical;
 #endif
-    double divisor_zoom = 16;
-    double zoom_scale = delta / 80 / divisor_zoom;
+    // Retrieve the scrollSpeed value from the settings
+    double scrollSpeed = AppConfig::Instance().appOptions.scrollSpeed;
+    double zoom_scale = delta / 80 * scrollSpeed;
 
     if (ABS_VAL(delta) <= 80){
-        zoom_scale = delta > 0 ? 1.5 / divisor_zoom : -1.5 / divisor_zoom;
+        zoom_scale = delta > 0 ? 1.5 * scrollSpeed : -1.5 * scrollSpeed;
     }
 
     if (_type == FFT_VIEW)


### PR DESCRIPTION
I and other users have been experiencing issues with the default scroll speed value, this pull adds a setting that multiplies the default value with the set value (default 1).

The config value is scrollSpeed and is saved with the other values in the default location.

Closes #599