### PR TITLE
Small style tweaks to improve usability

### DIFF
--- a/DSView/pv/dialogs/search.cpp
+++ b/DSView/pv/dialogs/search.cpp
@@ -24,6 +24,7 @@
 #include <assert.h>
 #include <QRegularExpressionValidator>
 #include <QTimer>
+#include <QFontDatabase>
 #include "../ui/langresource.h"
  
 
@@ -49,10 +50,7 @@ Search::Search(QWidget *parent, SigSession *session, std::map<uint16_t, QString>
     _session(session)
 {
 
-    QFont font("Monaco");
-    font.setStyleHint(QFont::Monospace);
-    font.setFixedPitch(true);
-    //this->setMinimumWidth(350);
+    QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
 
     QRegularExpression value_rx("[10XRFCxrfc]+");
     QValidator *value_validator = new QRegularExpressionValidator(value_rx, this);

--- a/DSView/pv/dock/triggerdock.cpp
+++ b/DSView/pv/dock/triggerdock.cpp
@@ -33,6 +33,7 @@
 #include <QSplitter>
 #include <QInputMethodEvent>
 #include <QApplication>
+#include <QFontDatabase>
 #include <math.h>
 #include <libsigrok.h>
 
@@ -564,11 +565,7 @@ void TriggerDock::setup_adv_tab()
     _value0_ext32_lineEdit_list.clear();
     _value1_ext32_lineEdit_list.clear();
 
-   // QFont font("Monaco");
-   // font.setStyleHint(QFont::Monospace);
-   // font.setFixedPitch(true);
-
-    QFont font = this->font();
+    QFont font = QFontDatabase::systemFont(QFontDatabase::FixedFont);
     font.setPointSizeF(AppConfig::Instance().appOptions.fontSize);
 
     _stage_tabWidget = new QTabWidget(_widget);
@@ -709,6 +706,7 @@ void TriggerDock::setup_adv_tab()
         stage_layout->addLayout(stage_glayout);
         stage_layout->addSpacing(20);
         QLabel *stage_note_label = new QLabel(_stage_tabWidget);
+        stage_note_label->setFont(font);
         _stage_note_label_list.push_back(stage_note_label);
         stage_layout->addWidget(stage_note_label);
         stage_layout->addStretch(1);
@@ -903,6 +901,8 @@ void TriggerDock::setup_adv_tab()
     serial_glayout->addWidget(hex_wid, row++, 1, 1, 3);
 
     _serial_note_label = new QLabel(_serial_groupBox);
+    _serial_note_label->setFont(font);
+
     serial_layout->addLayout(serial_glayout);
     serial_layout->addSpacing(20);
     serial_layout->addWidget(_serial_note_label);
@@ -1079,7 +1079,6 @@ void TriggerDock::UpdateFont()
 {
     QFont font = this->font();
     font.setPointSizeF(AppConfig::Instance().appOptions.fontSize);
-    ui::set_form_font(this, font);
     font.setPointSizeF(font.pointSizeF() + 1);
     this->parentWidget()->setFont(font);
     

--- a/DSView/pv/dock/triggerdock.cpp
+++ b/DSView/pv/dock/triggerdock.cpp
@@ -152,7 +152,6 @@ void TriggerDock::retranslateUi()
     _serial_edge_label->setText(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_CLOCK_FLAG), "Clock Flag: "));
     _serial_data_label->setText(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_DATA_CHANNEL), "Data Channel: "));
     _serial_value_label->setText(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_DATA_VALUE), "Data Value: "));
-    _serial_groupBox->setTitle(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_SERIAL_TRIGGER), "Serial Trigger"));
     _serial_hex_label->setText(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_SERIAL_HEX), "Hex: "));
     _serial_hex_ck_label->setText(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_SERIAL_INPUT_AS_HEX), "Input hex"));
 
@@ -172,10 +171,6 @@ void TriggerDock::retranslateUi()
 
     for (int i = 0; i < _contiguous_label_list.length(); i++){
         _contiguous_label_list.at(i)->setText(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_CONTIGUOUS), "Contiguous"));
-    }
-
-    for (int i = 0; i < _stage_groupBox_list.length(); i++){
-        _stage_groupBox_list.at(i)->setTitle(L_S(STR_PAGE_DLG, S_ID(IDS_DLG_STAGE), "Stage")+QString::number(i));
     }
 
     for (int i = 0; i < _stage_note_label_list.length(); i++){
@@ -714,6 +709,7 @@ void TriggerDock::setup_adv_tab()
         QGroupBox *stage_groupBox = new QGroupBox(_stage_tabWidget);
         stage_groupBox->setContentsMargins(5, 15, 5, 5);
         stage_groupBox->setFlat(true);
+        stage_groupBox->setStyleSheet("margin-top: 0px");
         stage_groupBox->setLayout(stage_layout);
         _stage_groupBox_list.push_back(stage_groupBox);
 
@@ -723,6 +719,7 @@ void TriggerDock::setup_adv_tab()
     _serial_groupBox = new QGroupBox(_widget);
     _serial_groupBox->setContentsMargins(5, 15, 5, 5);
     _serial_groupBox->setFlat(true);
+    _serial_groupBox->setStyleSheet("margin-top: 0px");
 
     _serial_start_label = new QLabel(_serial_groupBox);
     _serial_start_lineEdit = new PopupLineEdit("X X X X X X X X X X X X X X X X", _serial_groupBox);

--- a/DSView/themes/dark.qss
+++ b/DSView/themes/dark.qss
@@ -169,8 +169,8 @@ QRadioButton:disabled
 }
 QRadioButton::indicator
 {
-    width: 10px;
-    height: 10px;
+    width: 16px;
+    height: 16px;
 }
 
 QRadioButton::indicator:unchecked,
@@ -386,10 +386,10 @@ QGroupBox::title
 
 QScrollBar:horizontal
 {
-    height: 12px;
+    height: 24px;
     margin: 3px 12px 3px 12px;
     border: 1px transparent;
-    border-radius: 3px;
+    border-radius: 9px;
     background-color: #181818;
 }
 
@@ -397,7 +397,7 @@ QScrollBar::handle:horizontal
 {
     background-color: #6F6F6F;
     min-width: 20px;
-    border-radius: 3px;
+    border-radius: 9px;
 }
 
 QScrollBar::add-line:horizontal
@@ -457,17 +457,17 @@ QScrollBar::sub-page:horizontal
 QScrollBar:vertical
 {
     background-color: #181818;
-    width: 12px;
+    width: 24px;
     margin: 12px 3px 12px 3px;
     border: 1px transparent;
-    border-radius: 3px;
+    border-radius: 9px;
 }
 
 QScrollBar::handle:vertical
 {
     background-color: #6F6F6F;
     min-height: 20px;
-    border-radius: 3px;
+    border-radius: 9px;
 }
 
 QScrollBar::sub-line:vertical
@@ -1091,7 +1091,7 @@ QTreeView::branch:open:has-children:has-siblings
 QSlider::groove:horizontal
 {
     border: 1px solid #1F1F1F;
-    height: 1px;
+    height: 4px;
     background: #808080;
     margin: 0px;
     border-radius: 1px;
@@ -1101,10 +1101,9 @@ QSlider::handle:horizontal
 {
     background: #1F1F1F;
     border: 1px solid #1185D1;
-    width: 7px;
-    height: 7px;
-    margin: -4px 0;
-    border-radius: 4px;
+    width: 16px;
+    margin: -7px 0;
+    border-radius: 8px;
 }
 
 QSlider::groove:vertical

--- a/DSView/themes/light.qss
+++ b/DSView/themes/light.qss
@@ -166,8 +166,8 @@ QRadioButton:disabled
 }
 QRadioButton::indicator
 {
-    width: 10px;
-    height: 10px;
+    width: 16px;
+    height: 16px;
 }
 
 QRadioButton::indicator:unchecked,
@@ -386,10 +386,10 @@ QGroupBox::title
 
 QScrollBar:horizontal
 {
-    height: 12px;
+    height: 24px;
     margin: 3px 12px 3px 12px;
     border: 1px transparent;
-    border-radius: 3px;
+    border-radius: 9px;
     background-color: #F8F8F8;
 }
 
@@ -397,7 +397,7 @@ QScrollBar::handle:horizontal
 {
     background-color: #808080;
     min-width: 20px;
-    border-radius: 3px;
+    border-radius: 9px;
 }
 
 QScrollBar::add-line:horizontal
@@ -457,17 +457,17 @@ QScrollBar::sub-page:horizontal
 QScrollBar:vertical
 {
     background-color: #F8F8F8;
-    width: 12px;
+    width: 24px;
     margin: 12px 3px 12px 3px;
     border: 1px transparent;
-    border-radius: 3px;
+    border-radius: 9px;
 }
 
 QScrollBar::handle:vertical
 {
     background-color: #808080;
     min-height: 20px;
-    border-radius: 3px;
+    border-radius: 9px;
 }
 
 QScrollBar::sub-line:vertical
@@ -1130,7 +1130,7 @@ QTreeView::item:!selected:hover
 QSlider::groove:horizontal
 {
     border: 1px solid #F8F8F8;
-    height: 1px;
+    height: 4px;
     background: #808080;
     margin: 0px;
     border-radius: 1px;
@@ -1140,10 +1140,9 @@ QSlider::handle:horizontal
 {
     background: #F8F8F8;
     border: 1px solid #1185D1;
-    width: 7px;
-    height: 7px;
-    margin: -4px 0;
-    border-radius: 4px;
+    width: 16px;
+    margin: -7px 0;
+    border-radius: 8px;
 }
 
 QSlider::groove:vertical

--- a/libsigrok4DSL/strutil.c
+++ b/libsigrok4DSL/strutil.c
@@ -77,7 +77,7 @@ SR_API char *sr_si_string_u64(uint64_t x, const char *unit)
         return g_strdup_printf("%llu k%s",
                     (u64_t)(x / SR_KHZ(1)), unit);
     } else if ((x >= SR_KHZ(1)) && (x % SR_KHZ(1) != 0)) {
-        return g_strdup_printf("%llu.%llu K%s",
+        return g_strdup_printf("%llu.%llu k%s",
                     (u64_t)(x / SR_KHZ(1)), (u64_t)(x % SR_KHZ(1)), unit);
     } else {
         return g_strdup_printf("%llu %s", (u64_t)x, unit);


### PR DESCRIPTION
- Fixed width font is reinstated for Search and Trigger Dock. This was broken at least on Linux.
- Unnecessarily small UI elements have been enlarged so they are easier to click:
  - Scroll bars
  - Radio buttons
  - Sliders
- In the Trigger Dock, the GroupBox titles have been removed. These were redundant (as the Tabs already show the titles) and somewhat broke up the UI flow. The Stage Trigger and Serial Trigger boxes now sit flush with their Tabs at the top.
- Typo fixed: "KHz" -> "kHz".
