### PR TITLE
Fix app icon missing from taskbar on Wayland (e.g. COSMIC)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -669,7 +669,7 @@ install(FILES DSView/icons/logo.svg DESTINATION share/icons/hicolor/scalable/app
 install(FILES DSView/icons/logo.svg DESTINATION share/pixmaps RENAME dsview.svg)
 
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")	
-	install(FILES DSView/DSView.desktop DESTINATION /usr/share/applications RENAME dsview.desktop)
+	install(FILES DSView/DSView.desktop DESTINATION share/applications RENAME dsview.desktop)
 	
 	add_compile_definitions(_DEFAULT_SOURCE)
 

--- a/DSView/DSView.desktop
+++ b/DSView/DSView.desktop
@@ -6,5 +6,6 @@ Comment=GUI Program for DreamSourceLab USB-based Instruments
 TryExec=DSView
 Exec=DSView
 Icon=dsview
+StartupWMClass=DSView
 Terminal=false
 Categories=Development;Electronics;Qt;

--- a/DSView/main.cpp
+++ b/DSView/main.cpp
@@ -174,6 +174,7 @@ bool bHighScale = true;
     QApplication::setApplicationName("DSView");
     QApplication::setOrganizationName("DreamSourceLab");
     QApplication::setOrganizationDomain("www.DreamSourceLab.com");
+    QApplication::setDesktopFileName("dsview");
 
 	//----------------------init log
 	dsv_log_init(); // Don't call before QApplication be inited


### PR DESCRIPTION
## Summary

- Call `QApplication::setDesktopFileName("dsview")` so the Wayland app-id matches the desktop entry basename, allowing compositors (e.g. COSMIC) to correctly associate the running app with its icon
- Add `StartupWMClass=DSView` to the desktop file for equivalent X11 window manager matching
- Move the desktop file cmake install destination from the hardcoded `/usr/share/applications` to the install-prefix-relative `share/applications`, consistent with all other installed files

## Background

On Wayland, compositors match running apps to their `.desktop` entry using the app-id. Qt derives the app-id from `QGuiApplication::desktopFileName()`, falling back to the application name (`"DSView"`) if not set. Since the desktop file is named `dsview.desktop`, the case mismatch caused the icon to appear in the app launcher (search) but not in the taskbar for running apps.

## Test plan

- [x] Launch DSView on a Wayland compositor (e.g. COSMIC) — icon should appear in the taskbar when running
- [x] Icon appears in the app launcher/search
- [x] Launch DSView via XWayland — icon still matches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)